### PR TITLE
Fix budget phase label for 2013 outcome in 2015 budget

### DIFF
--- a/2015-16/national/fiscal.source-spec.yaml
+++ b/2015-16/national/fiscal.source-spec.yaml
@@ -113,7 +113,7 @@ measures:
     "2013/14 Adjusted appropriation":
       budget_phase: "Adjusted appropriation"
       financial_year: "2013"
-    "2013/14 Audited outcome":
+    "2013/14 Preliminary outcome":
       budget_phase: "Audited Outcome"
       financial_year: "2013"
     "2014/15 Voted (Main appropriation)":


### PR DESCRIPTION
Jeffery Smith
08:11 (2 hours ago)
to me, Greg
Hi JD

I think it is just a heading error as we don’t collect preliminary outcomes for the history years. Prelim only relates to the in-year. I also double checked in the ENE data collection template, where we have it as audited outcome.

Jeffery